### PR TITLE
Improve ESIOS file cache

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mamba
+mamba<0.11.0
 expects
 python-dateutil
 vcrpy


### PR DESCRIPTION
- Not cached REE files are downloaded only if certain time has passed since their last download.
- Minimum time for "re-downloading" is specified in `_CACHE_TIMEOUT` var.